### PR TITLE
Handling multiple scopes easily in get_authorize_url

### DIFF
--- a/preston/preston.py
+++ b/preston/preston.py
@@ -169,7 +169,7 @@ class Preston:
         """
         return (
             f"{self.AUTHORIZE_URL}?response_type=code&redirect_uri={self.callback_url}"
-            f"&client_id={self.client_id}&scope={self.scope}"
+            f"&client_id={self.client_id}&scope={self.scope.replace(' ', '%20')}"
         )
 
     def authenticate(self, code: str) -> "Preston":

--- a/tests/test_preston.py
+++ b/tests/test_preston.py
@@ -81,7 +81,10 @@ def test_is_access_token_expired(empty):
 def test_get_authorize_url(sample):
     expected = "https://login.eveonline.com/oauth/authorize?response_type=code&redirect_uri=4&client_id=2&scope=5"
     assert sample.get_authorize_url() == expected
-
+    sample_multiple_scopes = sample
+    sample_multiple_scopes.scope = 'scope1 scope2'
+    expected_multiple_scope = "https://login.eveonline.com/oauth/authorize?response_type=code&redirect_uri=4&client_id=2&scope=scope1%20scope2"
+    assert sample_multiple_scopes.get_authorize_url() == expected_multiple_scope
 
 def test_update_access_token_header(sample):
     assert "Authorization" not in sample.session.headers

--- a/tests/test_preston.py
+++ b/tests/test_preston.py
@@ -82,8 +82,8 @@ def test_get_authorize_url(sample):
     expected = "https://login.eveonline.com/oauth/authorize?response_type=code&redirect_uri=4&client_id=2&scope=5"
     assert sample.get_authorize_url() == expected
     sample_multiple_scopes = sample
-    sample_multiple_scopes.scope = 'scope1 scope2'
-    expected_multiple_scope = "https://login.eveonline.com/oauth/authorize?response_type=code&redirect_uri=4&client_id=2&scope=scope1%20scope2"
+    sample_multiple_scopes.scope = 'scope scope1'
+    expected_multiple_scope = "https://login.eveonline.com/oauth/authorize?response_type=code&redirect_uri=4&client_id=2&scope=scope%20scope1"
     assert sample_multiple_scopes.get_authorize_url() == expected_multiple_scope
 
 def test_update_access_token_header(sample):


### PR DESCRIPTION
If you use "Copy Scopes into Clipboard" from CCP Application Site, pass that value into Preston and run get_authorize_url, you will get URL with spaces kept intact. Depending on the browser, redirect method or other things, this could result in your auth request not properly getting handled on CCP end and access token not having all the permissions. This pull request will clean up that behavior by replacing spaces with %20 which is proper behavioir.