### PR TITLE
Fix authenticate() does not set access token header.

### DIFF
--- a/preston/preston.py
+++ b/preston/preston.py
@@ -144,9 +144,11 @@ class Preston:
                     self.access_expiration,
                 ) = self._get_access_from_refresh()
                 self.access_expiration = time.time() + self.access_expiration
-                self.session.headers.update(
-                    {"Authorization": f"Bearer {self.access_token}"}
-                )
+
+        if self.access_token:
+            self.session.headers.update(
+                {"Authorization": f"Bearer {self.access_token}"}
+            )
 
     def _is_access_token_expired(self) -> bool:
         """Returns true if the stored access token has expired.


### PR DESCRIPTION
When upgrading from Preston 4.6.0 to 4.8.0 on my project I ran into the problem that the authentication flow does not work anymore.

Here is a minimal example:
```python

from preston import Preston

preston = Preston(
    user_agent="....",
    client_id="....",
    client_secret="....",
    callback_url="....",
    scope="",
)


print(preston.get_authorize_url())

callback_url = input("Enter callback url?") # Workaround so we don't need to wait for dns
code = callback_url.split("code=")[1]
authed_preston = preston.authenticate(code)

print(authed_preston.whoami())
```
`authed_preston.whoami()` raises a `requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` Error.

Digging a bit deeper if I print the response that can not be decoded, if I modify the `whoami()` function to print out the response status code I get that ESI returns a 401 (Not Authorized).

Looking at the `authed_preston.session.headers` just before the `authed_preston.whoami()` function is called returns the following.
`{'User-Agent': 'preston testing by larynx', 'Accept-Encoding': 'gzip, deflate', 'Accept': 'application/json', 'Connection': 'keep-alive'}` - the headers do not include any authentication!

This seems to be because the [_try_refresh_access_token](https://github.com/Celeo/Preston/blob/master/preston/preston.py#L125) function only updates the header when it fetches a new access_token e.g. there is currently no access_token or it is expired. So if we set the access token in `__init__ ` (which does not set the headers itself) then `_try_refresh_access_token` does not set the headers either. You seem to have introduced that bug in 4.7.0.

To fix this I modified the `_try_refresh_access_token` function to update the header whenever there is an access_token (This also covers the case when you only have the `publicData` ESI scope, in which case you are not issued a `refresh_token`).